### PR TITLE
add parameter for passing authentication token to release tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ URL to the `.ico` file to use as the icon for the generated `Setup.exe`. [Defaul
 `remote_releases` - *String*
 URL to your existing updates. If given, these will be downloaded to create delta updates. [Default: `null`]
 
+`token` - *String*
+Token used to authenticate access to remote release API. [Default: `null`]
+
 `overwrite` - *Boolean*
 Overwrite existing installers if they already exist. [Default: `false`]
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,11 @@ function syncReleases(app, done) {
     });
   }
 
-  exec(SYNC_RELEASES_EXE, ['-u', app.remote_releases, '-r', app.out], done);
+  let syncArguments = ['-u', app.remote_releases, '-r', app.out];
+  if (app.token) {
+    syncArguments.push.apply(syncArguments, ['-t', app.token]);
+  }
+  exec(SYNC_RELEASES_EXE, syncArguments, done);
 }
 
 function createTempDirectory(app, done) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ function syncReleases(app, done) {
     });
   }
 
-  let syncArguments = ['-u', app.remote_releases, '-r', app.out];
+  var syncArguments = ['-u', app.remote_releases, '-r', app.out];
   if (app.token) {
     syncArguments.push.apply(syncArguments, ['-t', app.token]);
   }

--- a/lib/model.js
+++ b/lib/model.js
@@ -45,6 +45,7 @@ var App = Model.extend({
     cert_password: 'string',
     sign_with_params: 'string',
     remote_releases: 'string',
+    token: 'string',
     setup_filename: 'string',
     // @todo (imlucas): Support squirrel.windows `setup_icon`.
     nuget_id: 'string',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -52,7 +52,7 @@ describe('electron-installer-squirrel-windows', function() {
         assert.equal(app.name, 'Myapp');
         assert.equal(app.version, '0.0.0');
         assert.equal(app.description, 'A fixture Electron app for testing app packaging.');
-        assert.equal(app.copyright, '2015 Arlo Basil');
+        assert.equal(app.copyright, '2016 Arlo Basil');
         assert.equal(app.path, path.join(src));
         assert.equal(app.product_name, 'MyApp');
         assert.equal(app.electron_version, '0.29.2');
@@ -88,7 +88,7 @@ describe('electron-installer-squirrel-windows', function() {
           assert.equal(app.name, 'HelloEarl');
           assert.equal(app.version, '0.0.0');
           assert.equal(app.description, 'A fixture Electron app for testing app packaging.');
-          assert.equal(app.copyright, '2015 Arlo Basil');
+          assert.equal(app.copyright, '2016 Arlo Basil');
           assert.equal(app.path, path.join(options.path));
           assert.equal(app.product_name, 'MyApp');
           assert.equal(app.electron_version, '0.29.2');
@@ -120,7 +120,7 @@ describe('electron-installer-squirrel-windows', function() {
           assert.equal(app.name, 'Myapp');
           assert.equal(app.version, '0.0.0');
           assert.equal(app.description, 'A fixture Electron app for testing app packaging.');
-          assert.equal(app.copyright, '2015 Arlo Basil');
+          assert.equal(app.copyright, '2016 Arlo Basil');
           assert.equal(app.path, path.join(options.path));
           assert.equal(app.product_name, 'MyApp');
           assert.equal(app.electron_version, '0.29.2');


### PR DESCRIPTION
Adds a `token` configuration when authentication is needed to publish on the repository releases.

I've been working on a similar project to this one.  Yours is very nicely written. 

Using a token to authentication with the GitHub API is the only significant difference I can find that prevents me from dropping my fork and using this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/electron-installer-squirrel-windows/8)

<!-- Reviewable:end -->
