### PR TITLE
Added missing link to electron-packager

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,4 @@ Based on [atom/grunt-electron-installer][original] Copyright (c) 2015 GitHub Inc
 [squirrel]: https://github.com/Squirrel/Squirrel.Windows
 [original]: https://github.com/atom/grunt-electron-installer
 [electron-squirrel-startup]: https://github.com/mongodb-js/electron-squirrel-startup
+[electron-packager]: https://github.com/electron-userland/electron-packager


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/electron-installer-squirrel-windows/13)

<!-- Reviewable:end -->
